### PR TITLE
Fix command to detect aiida-project `aiida_venv_dir` variable

### DIFF
--- a/aiida-backup.sh
+++ b/aiida-backup.sh
@@ -74,7 +74,7 @@ aiida-project)
     if [ ! -f "$HOME/.aiida_project.env" ]; then
         echo ".aiida_project.env not found in user home directory. Is aiida-project initialized?" && exit 1
     fi
-    export "$(grep -v '^#' "$HOME/.aiida_project.env" | xargs)"
+    export $(grep -v '^#' "$HOME/.aiida_project.env" | xargs)
     source "$aiida_venv_dir/$project/bin/activate"
     ;;
 *)


### PR DESCRIPTION
Hi @edan-bainglass 

I had to do the change below, as my CRON tasks were failing. The `aiida_venv_dir` variable was not actually set with your previous command. To my understanding, due to thew quotation marks, it was trying to set all the variable that were read from `.aiida_project.env` to a single variable. Removing the quotation marks fixed it for me.

Of course, please verify etc.